### PR TITLE
Wrong parsing result with decimals like 1.8

### DIFF
--- a/src/IxMilia.Step/StepTokenizer.cs
+++ b/src/IxMilia.Step/StepTokenizer.cs
@@ -345,7 +345,7 @@ namespace IxMilia.Step
 
             var str = sb.ToString();
             return seenDecimal || seenE
-                ? (StepToken)new StepRealToken(double.Parse(str), tokenLine, tokenColumn)
+                ? (StepToken)new StepRealToken(double.Parse(str, System.Globalization.CultureInfo.InvariantCulture), tokenLine, tokenColumn)
                 : new StepIntegerToken(int.Parse(str), tokenLine, tokenColumn);
         }
 


### PR DESCRIPTION
Get Value of '1.8' instead of '18'
#37=VECTOR($,#118,1.8);